### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,7 @@ if(EMSCRIPTEN)
 
     set(CMAKE_EXECUTABLE_SUFFIX ".html")
 elseif(ANDROID)
+    add_link_options("-Wl,-z,max-page-size=16384")
 elseif(UNIX)
     if(APPLE)
 	    set(CMAKE_MACOSX_RPATH ON)


### PR DESCRIPTION
Set page size for the Android platform in order to support Play Store 16KB requirements

Successfully compared the outcome of building for ABI arm64-v8a with and without the max-page-size, using llvm-objdump, which showed that it indeed does ensure that the shared output libraries are 16 kb aligned.